### PR TITLE
Fix README code fencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # DiScEPT
 
-```markdown
 # Discept UI
 
 **Discept UI** is a React-based frontend application designed to work with TEI (Text Encoding Initiative) files, providing features for displaying and editing these files, as well as future integration with IIIF image sources.
@@ -39,5 +38,3 @@ npm start
 ```
 
 This will start the development server, and you can open the application in your browser at [http://localhost:3000](http://localhost:3000).
-```
-


### PR DESCRIPTION
## Summary
- fix the unclosed code fence at the top of README so headings render normally

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842048b048083219a75a7612f18f76a