### PR TITLE
Fix alignment preview classname typo

### DIFF
--- a/public/CETEI.css
+++ b/public/CETEI.css
@@ -6,6 +6,6 @@
   background-color: blue;
 }
 
-.previewAligmentTEI {
+.previewAlignmentTEI {
   background-color: yellow !important;
 }

--- a/src/views/alignment.js
+++ b/src/views/alignment.js
@@ -228,7 +228,7 @@ class AlignmentView extends React.Component {
       this.setState({ listRefreshNeeded: this.state.listRefreshNeeded + 1 });
     };
 
-    const showAligment = (index) => {
+    const showAlignment = (index) => {
       const a = data.getAlignments(
         this.state.tabALanguage,
         this.state.tabBLanguage,
@@ -241,17 +241,17 @@ class AlignmentView extends React.Component {
         obj.a
           .map((id) => document.getElementById(id))
           .filter((elm) => elm)
-          .forEach((elm) => elm.classList.add("previewAligmentTEI"));
+          .forEach((elm) => elm.classList.add("previewAlignmentTEI"));
         obj.b
           .map((id) => document.getElementById(id))
           .filter((elm) => elm)
-          .forEach((elm) => elm.classList.add("previewAligmentTEI"));
+          .forEach((elm) => elm.classList.add("previewAlignmentTEI"));
       });
     };
 
-    const hideAligment = (index) => {
-      Array.from(document.getElementsByClassName("previewAligmentTEI")).forEach(
-        (elm) => elm.classList.remove("previewAligmentTEI"),
+    const hideAlignment = (index) => {
+      Array.from(document.getElementsByClassName("previewAlignmentTEI")).forEach(
+        (elm) => elm.classList.remove("previewAlignmentTEI"),
       );
     };
 
@@ -339,8 +339,8 @@ class AlignmentView extends React.Component {
                     <ListItemButton>
                       <ListItemText
                         primary={"Alignment " + (index + 1)}
-                        onMouseOut={() => hideAligment(index)}
-                        onMouseOver={() => showAligment(index)}
+                        onMouseOut={() => hideAlignment(index)}
+                        onMouseOver={() => showAlignment(index)}
                       />
                     </ListItemButton>
                   </ListItem>

--- a/src/views/image.js
+++ b/src/views/image.js
@@ -105,13 +105,13 @@ class ImageView extends React.Component {
         obj.ids
           .map((id) => document.getElementById(id))
           .filter((elm) => elm)
-          .forEach((elm) => elm.classList.add("previewAligmentTEI"));
+          .forEach((elm) => elm.classList.add("previewAlignmentTEI"));
       });
     };
 
     const hideImage = (index) => {
-      Array.from(document.getElementsByClassName("previewAligmentTEI")).forEach(
-        (elm) => elm.classList.remove("previewAligmentTEI"),
+      Array.from(document.getElementsByClassName("previewAlignmentTEI")).forEach(
+        (elm) => elm.classList.remove("previewAlignmentTEI"),
       );
     };
 


### PR DESCRIPTION
## Summary
- rename `.previewAligmentTEI` to `.previewAlignmentTEI`
- update usage in alignment and image views
- rename helper functions in alignment view to use correct spelling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420463a9c88321bbe460b468b6af6c