### PR TITLE
Move generateTEI Jest test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --watchAll=false",
     "eject": "react-scripts eject"
   },
   "dependencies": {
@@ -35,5 +35,11 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "*",
     "prettier": "3.2.5"
+  },
+  "jest": {
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/tests"
+    ]
   }
 }

--- a/tests/Data.test.js
+++ b/tests/Data.test.js
@@ -1,0 +1,7 @@
+import Data from '../src/Data';
+
+test('generateTEI includes TEI root and teiHeader', () => {
+  const xml = Data.generateTEI();
+  expect(xml).toContain('<TEI');
+  expect(xml).toContain('<teiHeader>');
+});


### PR DESCRIPTION
## Summary
- move `Data.test.js` from `src/__tests__` to a new `tests` folder
- configure Jest so tests in `tests/` are discovered

## Testing
- `npm test -- tests/Data.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420981f4408321a0b576335111fc4e