### PR TITLE
Add close button to stepper

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -67,6 +67,7 @@ class App extends React.Component {
       currentStep: 0,
       fileUploaded: null,
       runOnboarding: false,
+      stepperOpen: true,
     };
   }
 
@@ -92,6 +93,11 @@ class App extends React.Component {
       this.setState({ runOnboarding: true });
     };
 
+    // Function to toggle the visibility of the stepper
+    const toggleStepper = () => {
+      this.setState((state) => ({ stepperOpen: !state.stepperOpen }));
+    };
+
     // Function to stop the onboarding process once it's completed
     const onboardingCompleted = () => {
       this.setState({ runOnboarding: false });
@@ -101,13 +107,30 @@ class App extends React.Component {
       <ThemeProvider theme={theme}>
         <CssBaseline />
 
-        <DisceptAppBar fileUploaded={fileUploaded} onHelp={runOnboarding} />
+        <DisceptAppBar
+          fileUploaded={fileUploaded}
+          onHelp={runOnboarding}
+          onToggleStepper={toggleStepper}
+          stepperOpen={this.state.stepperOpen}
+        />
 
-        <Grid container spacing={2} sx={{ p: 3 }}>
-          <Grid item xs={2}>
-            <DisceptStepper steps={steps} onChange={changeStep} />
+        <Grid container spacing={2} sx={{ p: 3, position: "relative" }}>
+          <Grid
+            item
+            sx={{
+              width: this.state.stepperOpen ? 240 : 16,
+              transition: "width 0.2s ease",
+              mr: 3,
+            }}
+          >
+            <DisceptStepper
+              steps={steps}
+              onChange={changeStep}
+              onToggle={toggleStepper}
+              open={this.state.stepperOpen}
+            />
           </Grid>
-          <Grid item xs={10}>
+          <Grid item xs>
             <Item step={this.state.currentStep} />
           </Grid>
         </Grid>

--- a/src/components/appbar.js
+++ b/src/components/appbar.js
@@ -12,6 +12,8 @@ import {
 } from "@mui/material";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload"; // Icon representing file upload
 import HelpIcon from "@mui/icons-material/Help"; // Help icon, typically for an assistance or info button
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 
 // Hidden input styled component for file upload input, visually hidden but still accessible for screen readers
 const VisuallyHiddenInput = styled("input")({
@@ -27,7 +29,14 @@ const VisuallyHiddenInput = styled("input")({
 });
 
 // DisceptAppBar Component - A custom AppBar component with logo, file upload, and help button
-export default function DisceptAppBar({ fileUploaded, onHelp, darkMode, toggleDarkMode }) {
+export default function DisceptAppBar({
+  fileUploaded,
+  onHelp,
+  darkMode,
+  toggleDarkMode,
+  onToggleStepper,
+  stepperOpen,
+}) {
   // Handles file upload event
   // Checks that only one file is selected, then triggers the fileUploaded callback with the selected file
   const fileUpload = (e) => {
@@ -60,6 +69,15 @@ export default function DisceptAppBar({ fileUploaded, onHelp, darkMode, toggleDa
           </Box>
 
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+
+            {/* Toggle stepper */}
+            {onToggleStepper && (
+              <Tooltip title={stepperOpen ? "Nascondi menu" : "Mostra menu"}>
+                <IconButton color="inherit" onClick={onToggleStepper}>
+                  {stepperOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+                </IconButton>
+              </Tooltip>
+            )}
 
             {/* Upload */}
             <Tooltip title="Upload file">

--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -8,8 +8,11 @@ import {
   StepContent,
   Button,
   Typography,
+  IconButton,
 } from "@mui/material";
 import { styled, useTheme } from "@mui/material/styles";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 
 const StyledButton = styled(Button)(({ theme }) => ({
   textTransform: "none",
@@ -23,12 +26,31 @@ const StyledButton = styled(Button)(({ theme }) => ({
   },
 }));
 
-const StepperContainer = styled(Box)(({ theme }) => ({
-  maxWidth: 400,
+const StepperContainer = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "open",
+})(({ theme, open }) => ({
+  width: open ? 240 : 16,
+  minHeight: "100vh",
+  overflow: "visible",
+  position: "relative",
   backgroundColor: theme.palette.background.paper,
-  padding: theme.spacing(2),
+  padding: open ? theme.spacing(2) : theme.spacing(0.5),
   borderRadius: 12,
   boxShadow: "0 4px 12px rgba(0,0,0,0.04)",
+  transition: "width 0.2s ease",
+}));
+
+const ToggleButton = styled(IconButton)(({ theme }) => ({
+  position: "absolute",
+  top: "50%",
+  right: -20,
+  transform: "translateY(-50%)",
+  backgroundColor: theme.palette.background.paper,
+  boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+  zIndex: 1,
+  "&:hover": {
+    backgroundColor: theme.palette.action.hover,
+  },
 }));
 
 const StyledStep = styled(Step)(({ theme, active }) => ({
@@ -39,7 +61,7 @@ const StyledStep = styled(Step)(({ theme, active }) => ({
 }));
 
 // DisceptStepper Component - Renders a vertical stepper with a sequence of steps, displaying each step's label and description. Allows navigation between steps by clicking on labels.
-export default function DisceptStepper({ steps, onChange }) {
+export default function DisceptStepper({ steps, onChange, onToggle, open }) {
   // State for tracking the currently active step
   const [activeStep, setActiveStep] = React.useState(0);
   const theme = useTheme();
@@ -51,23 +73,28 @@ export default function DisceptStepper({ steps, onChange }) {
   };
 
   return (
-    <StepperContainer>
-      <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map((step, index) => (
-          <StyledStep key={step.label} active={activeStep === index}>
-            <StepLabel>
-              <StyledButton onClick={() => activate(index)}>
-                {step.label}
-              </StyledButton>
-            </StepLabel>
-            <StepContent>
-              <Typography sx={{ color: "text.secondary", mb: 1 }}>
-                {step.description}
-              </Typography>
-            </StepContent>
-          </StyledStep>
-        ))}
-      </Stepper>
+    <StepperContainer open={open}>
+      <ToggleButton size="small" onClick={onToggle}>
+        {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+      </ToggleButton>
+      {open && (
+        <Stepper activeStep={activeStep} orientation="vertical">
+          {steps.map((step, index) => (
+            <StyledStep key={step.label} active={activeStep === index}>
+              <StepLabel>
+                <StyledButton onClick={() => activate(index)}>
+                  {step.label}
+                </StyledButton>
+              </StepLabel>
+              <StepContent>
+                <Typography sx={{ color: "text.secondary", mb: 1 }}>
+                  {step.description}
+                </Typography>
+              </StepContent>
+            </StyledStep>
+          ))}
+        </Stepper>
+      )}
     </StepperContainer>
   );
 }


### PR DESCRIPTION
## Summary
- add topbar button to toggle Stepper
- keep Stepper collapsed as a full-height bar with visible chevron
- allow the toggle chevron to sit above content when collapsed
- add margin when the stepper is closed so the chevron never overlaps content
- ensure the same spacing even when the stepper is open

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684203f12af48321ae715890ca56b165