### PR TITLE
Add intro link in app bar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -103,6 +103,11 @@ class App extends React.Component {
       this.setState({ runOnboarding: false });
     };
 
+    // Function to navigate back to the intro step
+    const goToIntro = () => {
+      changeStep(0);
+    };
+
     return (
       <ThemeProvider theme={theme}>
         <CssBaseline />
@@ -112,6 +117,7 @@ class App extends React.Component {
           onHelp={runOnboarding}
           onToggleStepper={toggleStepper}
           stepperOpen={this.state.stepperOpen}
+          onIntro={goToIntro}
         />
 
         <Grid container spacing={2} sx={{ p: 3, position: "relative" }}>

--- a/src/components/appbar.js
+++ b/src/components/appbar.js
@@ -36,6 +36,7 @@ export default function DisceptAppBar({
   toggleDarkMode,
   onToggleStepper,
   stepperOpen,
+  onIntro,
 }) {
   // Handles file upload event
   // Checks that only one file is selected, then triggers the fileUploaded callback with the selected file
@@ -57,7 +58,10 @@ export default function DisceptAppBar({
         }}
       >
         <Toolbar sx={{ justifyContent: "space-between", px: 2 }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box
+            sx={{ display: "flex", alignItems: "center", gap: 1, cursor: "pointer" }}
+            onClick={() => onIntro && onIntro()}
+          >
             <img
               src="assets/logo.png"
               alt="Logo"


### PR DESCRIPTION
## Summary
- add goToIntro helper in App and use it for DisceptAppBar
- trigger this callback when clicking the logo/text in the app bar

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421013f7688321b1168ba848d979a9