### PR TITLE
Add alignment category selection

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -27,6 +27,15 @@ const TEIStandOffStatement = (dom) =>
     null,
   );
 
+// Fixed list of categories for alignment links
+// The categories are: Linguistic, Semantic, Literal, Other
+export const ALIGNMENT_CATEGORIES = [
+  "Linguistic",
+  "Semantic",
+  "Literal",
+  "Other",
+];
+
 const helpers = [
   // Template
   {
@@ -364,6 +373,7 @@ const helpers = [
               const obj = {
                 a: targets[0] in joinList ? joinList[targets[0]] : [targets[0]],
                 b: targets[1] in joinList ? joinList[targets[1]] : [targets[1]],
+                category: link.getAttribute("type") || ALIGNMENT_CATEGORIES[0],
               };
               aligns.push(obj);
 
@@ -449,6 +459,9 @@ const helpers = [
 
           const link = dom.createElementNS(TEI_NS, "link");
           link.setAttribute("target", `#${joinIdA} #${joinIdB}`);
+          if (align.category) {
+            link.setAttribute("type", align.category);
+          }
           linkGrp.appendChild(link);
         }
 
@@ -554,6 +567,7 @@ class Data {
     return a.alignments.map((obj) => ({
       a: obj.b,
       b: obj.a,
+      category: obj.category,
     }));
   }
 
@@ -567,7 +581,7 @@ class Data {
     this.#changed = true;
   }
 
-  addAlignment(langA, langB, idsA, idsB) {
+  addAlignment(langA, langB, idsA, idsB, category = ALIGNMENT_CATEGORIES[0]) {
     const a = this.#getAlignments(langA, langB);
     if (!a) {
       this.#alignments.push({
@@ -577,6 +591,7 @@ class Data {
           {
             a: idsA,
             b: idsB,
+            category,
           },
         ],
       });
@@ -589,6 +604,7 @@ class Data {
       a.alignments.push({
         a: idsA,
         b: idsB,
+        category,
       });
       return;
     }
@@ -596,6 +612,7 @@ class Data {
     a.alignments.push({
       a: idsB,
       b: idsA,
+      category,
     });
   }
 

--- a/src/views/alignment.js
+++ b/src/views/alignment.js
@@ -2,8 +2,11 @@ import React from "react";
 
 import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
-import ButtonGroup from "@mui/material/ButtonGroup";
 import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
@@ -15,7 +18,7 @@ import AlignTab from "../components/aligntab.js";
 import AutomagicButton from "../components/automagicbutton.js";
 import Title from "../components/title.js";
 
-import data from "../Data.js";
+import data, { ALIGNMENT_CATEGORIES } from "../Data.js";
 
 const TEI_NS = "http://www.tei-c.org/ns/1.0";
 
@@ -30,6 +33,7 @@ class AlignmentView extends React.Component {
       tabBSelections: [],
       tabBRefreshNeeded: 0,
       listRefreshNeeded: 0,
+      category: ALIGNMENT_CATEGORIES[0],
     };
   }
 
@@ -180,6 +184,7 @@ class AlignmentView extends React.Component {
         this.state.tabBLanguage,
         langAIds,
         langBIds,
+        this.state.category,
       );
 
       for (const tab of [
@@ -250,10 +255,13 @@ class AlignmentView extends React.Component {
     };
 
     const hideAlignment = (index) => {
-      Array.from(document.getElementsByClassName("previewAlignmentTEI")).forEach(
-        (elm) => elm.classList.remove("previewAlignmentTEI"),
-      );
+      Array.from(
+        document.getElementsByClassName("previewAlignmentTEI"),
+      ).forEach((elm) => elm.classList.remove("previewAlignmentTEI"));
     };
+
+    const linkDisabled =
+      !this.state.tabASelections.length || !this.state.tabBSelections.length;
 
     return (
       <Box>
@@ -300,38 +308,58 @@ class AlignmentView extends React.Component {
             </Box>
           </Grid>
           <Grid item xs={3}>
-            <ButtonGroup aria-label="button group" orientation="vertical">
-              <Button
-                id="alignment-link"
-                variant="contained"
-                disabled={
-                  !this.state.tabASelections.length ||
-                  !this.state.tabBSelections.length
-                }
-                onClick={createLink}
-              >
-                Link selections
-              </Button>
-              <Button
-                id="tokenize-link"
-                variant="contained"
-                disabled={
-                  (!this.state.tabASelections.length &&
-                    !this.state.tabBSelections.length) ||
-                  (this.state.tabASelections.length &&
-                    this.state.tabBSelections.length)
-                }
-                onClick={tokenizeLink}
-              >
-                Tokenize selection
-              </Button>
-              <AutomagicButton
-                languageA={this.state.tabALanguage}
-                languageB={this.state.tabBLanguage}
-              >
-                AI alignment
-              </AutomagicButton>
-            </ButtonGroup>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                <Button
+                  id="tokenize-link"
+                  variant="contained"
+                  disabled={
+                    (!this.state.tabASelections.length &&
+                      !this.state.tabBSelections.length) ||
+                    (this.state.tabASelections.length &&
+                      this.state.tabBSelections.length)
+                  }
+                  onClick={tokenizeLink}
+                >
+                  Tokenize selection
+                </Button>
+                <AutomagicButton
+                  languageA={this.state.tabALanguage}
+                  languageB={this.state.tabBLanguage}
+                >
+                  AI alignment
+                </AutomagicButton>
+              </Box>
+
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                <Button
+                  id="alignment-link"
+                  variant="contained"
+                  disabled={linkDisabled}
+                  onClick={createLink}
+                >
+                  Link selections
+                </Button>
+                <FormControl disabled={linkDisabled} fullWidth>
+                  <InputLabel id="category-select-label">Category</InputLabel>
+                  <Select
+                    labelId="category-select-label"
+                    id="category-select"
+                    value={this.state.category}
+                    label="Category"
+                    onChange={(e) =>
+                      this.setState({ category: e.target.value })
+                    }
+                  >
+                    {ALIGNMENT_CATEGORIES.map((cat) => (
+                      <MenuItem value={cat} key={"cat-" + cat}>
+                        {cat}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
+            </Box>
             <List key={"list-" + this.state.listRefreshNeeded}>
               {data
                 .getAlignments(this.state.tabALanguage, this.state.tabBLanguage)


### PR DESCRIPTION
## Summary
- add `ALIGNMENT_CATEGORIES` list in `Data.js`
- store category when adding or parsing alignments
- expose category on generated TEI links
- allow selecting category in alignment view
- restructure buttons and disable the category select unless “Link selections” is active

## Testing
- `npm test` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68421220fdfc83219e5bd41655810bb0