### PR TITLE
Store alignment category in join elements

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -442,6 +442,9 @@ const helpers = [
               align.a.map((id) => "#" + id).join(" "),
             );
             joinA.setAttribute("xml:id", joinIdA);
+            if (align.category) {
+              joinA.setAttribute("type", align.category);
+            }
             standOff.appendChild(joinA);
           }
 
@@ -454,6 +457,9 @@ const helpers = [
               align.b.map((id) => "#" + id).join(" "),
             );
             joinB.setAttribute("xml:id", joinIdB);
+            if (align.category) {
+              joinB.setAttribute("type", align.category);
+            }
             standOff.appendChild(joinB);
           }
 

--- a/tests/Data.test.js
+++ b/tests/Data.test.js
@@ -5,3 +5,9 @@ test('generateTEI includes TEI root and teiHeader', () => {
   expect(xml).toContain('<TEI');
   expect(xml).toContain('<teiHeader>');
 });
+
+test('alignment category added as join type', () => {
+  Data.addAlignment('en', 'de', ['a1', 'a2'], ['b1', 'b2'], 'Semantic');
+  const xml = Data.generateTEI();
+  expect(xml).toMatch(/<join[^>]*type="Semantic"/);
+});


### PR DESCRIPTION
## Summary
- store alignment category on TEI `<join>` elements as `type`
- test that generated TEI `<join>` elements include the category

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421771fcb48321b07550535ec63aab