### PR TITLE
Fix tokenizer selection clearing

### DIFF
--- a/src/views/alignment.js
+++ b/src/views/alignment.js
@@ -135,13 +135,20 @@ class AlignmentView extends React.Component {
           selections[0].teiElm.ownerDocument.firstElementChild.outerHTML,
         );
 
+        selections.forEach((a) => {
+          a.domElm.classList.remove("selectedTEI");
+          a.domElm.classList.remove("selectableTEI");
+        });
+
         if (isA) {
           this.setState({
             tabARefreshNeeded: this.state.tabARefreshNeeded + 1,
+            tabASelections: [],
           });
         } else {
           this.setState({
             tabBRefreshNeeded: this.state.tabBRefreshNeeded + 1,
+            tabBSelections: [],
           });
         }
       }


### PR DESCRIPTION
## Summary
- clear selection and highlight when tokenizing text

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a402c3548321a513403d553d3020