### PR TITLE
Remember selected languages in editor and image views

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import * as React from "react"; // Import the React library
 import Grid from "@mui/material/Grid"; // Import Grid component from Material-UI
-import { ThemeProvider, CssBaseline } from '@mui/material';
+import { ThemeProvider, CssBaseline } from "@mui/material";
 
 // Custom components
 import DisceptAppBar from "./components/appbar.js";
@@ -17,7 +17,7 @@ import { EditorView, EditorOnboarding } from "./views/editor.js";
 import { AlignmentView, AlignmentOnboarding } from "./views/alignment.js";
 import { ImageView, ImageOnboarding } from "./views/image.js";
 import { FinalView, FinalOnboarding } from "./views/final.js";
-import theme from './Theme.js';
+import theme from "./Theme.js";
 
 // Define steps of the app, each with a view component and an optional onboarding process
 const steps = [
@@ -69,6 +69,10 @@ class App extends React.Component {
       fileUploaded: null,
       runOnboarding: false,
       stepperOpen: true,
+      alignmentTabALanguage: "",
+      alignmentTabBLanguage: "",
+      editorLanguage: "",
+      imageLanguage: "",
     };
   }
 
@@ -76,6 +80,45 @@ class App extends React.Component {
     // Functional component for rendering the view of the current step
     const Item = ({ step }) => {
       const Component = steps[step].component;
+
+      // Provide additional props for the Alignment view so that the selected
+      // languages persist when navigating through the steps.
+      if (Component === AlignmentView) {
+        return (
+          <Component
+            tabALanguage={this.state.alignmentTabALanguage}
+            tabBLanguage={this.state.alignmentTabBLanguage}
+            onLanguageChanged={(id, lang) =>
+              this.setState(
+                id === "tabA"
+                  ? { alignmentTabALanguage: lang }
+                  : { alignmentTabBLanguage: lang },
+              )
+            }
+          />
+        );
+      }
+
+      if (Component === EditorView) {
+        return (
+          <Component
+            language={this.state.editorLanguage}
+            onLanguageChanged={(lang) =>
+              this.setState({ editorLanguage: lang })
+            }
+          />
+        );
+      }
+
+      if (Component === ImageView) {
+        return (
+          <Component
+            language={this.state.imageLanguage}
+            onLanguageChanged={(lang) => this.setState({ imageLanguage: lang })}
+          />
+        );
+      }
+
       return <Component />; // Render the view component for the current step
     };
 

--- a/src/views/alignment.js
+++ b/src/views/alignment.js
@@ -26,10 +26,12 @@ class AlignmentView extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      tabALanguage: "",
+      // Initialize languages from props so that selections can be preserved
+      // when navigating away from this view and coming back.
+      tabALanguage: props.tabALanguage || "",
       tabASelections: [],
       tabARefreshNeeded: 0,
-      tabBLanguage: "",
+      tabBLanguage: props.tabBLanguage || "",
       tabBSelections: [],
       tabBRefreshNeeded: 0,
       listRefreshNeeded: 0,
@@ -204,6 +206,9 @@ class AlignmentView extends React.Component {
       const newState = {};
       newState[id === "tabA" ? "tabALanguage" : "tabBLanguage"] = language;
       this.setState(newState);
+      if (this.props.onLanguageChanged) {
+        this.props.onLanguageChanged(id, language);
+      }
     };
 
     const updateSelection = (id, domElm, teiElm, rootElm) => {
@@ -281,6 +286,7 @@ class AlignmentView extends React.Component {
                 <Grid item xs={6}>
                   <AlignTab
                     id="tabA"
+                    language={this.state.tabALanguage}
                     onLanguageChanged={(language) =>
                       languageChanged("tabA", language)
                     }
@@ -294,6 +300,7 @@ class AlignmentView extends React.Component {
                 <Grid item xs={6}>
                   <AlignTab
                     id="tabB"
+                    language={this.state.tabBLanguage}
                     onLanguageChanged={(language) =>
                       languageChanged("tabB", language)
                     }

--- a/src/views/editor.js
+++ b/src/views/editor.js
@@ -19,7 +19,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import TextField from "@mui/material/TextField";
 
 import EditorTab from "../components/editortab.js";
-import Title from '../components/title.js';
+import Title from "../components/title.js";
 import data from "../Data.js";
 
 const documentTemplate = (
@@ -47,10 +47,21 @@ const documentTemplate = (
  </text>
 </TEI>`;
 
-function EditorView() {
+function EditorView({ language, onLanguageChanged }) {
   const [selectedLanguage, setSelectedLanguage] = React.useState(
-    data.getDocumentLanguages()[0],
+    language || data.getDocumentLanguages()[0],
   );
+
+  React.useEffect(() => {
+    if (language) {
+      setSelectedLanguage(language);
+    }
+  }, [language]);
+
+  const changeLanguage = (lang) => {
+    if (onLanguageChanged) onLanguageChanged(lang);
+    setSelectedLanguage(lang);
+  };
   const [deletingLanguage, setDeletingLanguage] = React.useState("");
   const [addLanguageDialogShown, setAddLanguageDialogShown] =
     React.useState(false);
@@ -70,7 +81,7 @@ function EditorView() {
 
     if (deletingLanguage === selectedLanguage) {
       const languages = data.getDocumentLanguages();
-      setSelectedLanguage(languages.length ? languages[0] : "");
+      changeLanguage(languages.length ? languages[0] : "");
     }
   }
 
@@ -90,7 +101,7 @@ function EditorView() {
         addingLanguage,
         documentTemplate(addingLanguage),
       );
-      setSelectedLanguage(addingLanguage);
+      changeLanguage(addingLanguage);
     }
   }
 
@@ -124,7 +135,7 @@ function EditorView() {
               }
             >
               <ListItemButton
-                onClick={() => setSelectedLanguage(language)}
+                onClick={() => changeLanguage(language)}
                 selected={selectedLanguage === language}
               >
                 <ListItemText primary={language} />

--- a/src/views/image.js
+++ b/src/views/image.js
@@ -17,7 +17,7 @@ import InputLabel from "@mui/material/InputLabel";
 
 import AlignTab from "../components/aligntab.js";
 import OpenSeaDragon from "../components/openseadragon.js";
-import Title from '../components/title.js';
+import Title from "../components/title.js";
 
 import data from "../Data.js";
 
@@ -25,7 +25,7 @@ class ImageView extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      language: "",
+      language: props.language || "",
       selections: [],
       listRefreshNeeded: 0,
       imageURL: "",
@@ -74,6 +74,9 @@ class ImageView extends React.Component {
 
     const languageChanged = (language) => {
       this.setState({ language });
+      if (this.props.onLanguageChanged) {
+        this.props.onLanguageChanged(language);
+      }
     };
 
     const updateSelection = (domElm, teiElm, rootElm) => {
@@ -110,9 +113,9 @@ class ImageView extends React.Component {
     };
 
     const hideImage = (index) => {
-      Array.from(document.getElementsByClassName("previewAlignmentTEI")).forEach(
-        (elm) => elm.classList.remove("previewAlignmentTEI"),
-      );
+      Array.from(
+        document.getElementsByClassName("previewAlignmentTEI"),
+      ).forEach((elm) => elm.classList.remove("previewAlignmentTEI"));
     };
 
     const handleURLChange = (e) => {
@@ -133,6 +136,7 @@ class ImageView extends React.Component {
           <Grid item xs={9}>
             <AlignTab
               id="tab"
+              language={this.state.language}
               onLanguageChanged={languageChanged}
               onSelectionChanged={updateSelection}
             />


### PR DESCRIPTION
## Summary
- preserve language selection across steps for editor and image views
- pass initial languages from App state

## Testing
- `npx prettier -w src/App.js src/views/editor.js src/views/image.js`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a62743288321879b660971a87693