### PR TITLE
Fix highlight bug in TEI alignment

### DIFF
--- a/src/components/aligntab.js
+++ b/src/components/aligntab.js
@@ -53,16 +53,16 @@ class AlignTab extends React.Component {
         e.stopPropagation();
       });
 
-      domElm.addEventListener("mouseover", (e) => {
-        if (!e.target.classList.contains("selectedTEI")) {
-          e.target.classList.add("selectableTEI");
+      domElm.addEventListener("mouseenter", (e) => {
+        if (!domElm.classList.contains("selectedTEI")) {
+          domElm.classList.add("selectableTEI");
         }
         e.stopPropagation();
       });
 
-      domElm.addEventListener("mouseout", (e) => {
-        if (!e.target.classList.contains("selectedTEI")) {
-          e.target.classList.remove("selectableTEI");
+      domElm.addEventListener("mouseleave", (e) => {
+        if (!domElm.classList.contains("selectedTEI")) {
+          domElm.classList.remove("selectableTEI");
         }
         e.stopPropagation();
       });


### PR DESCRIPTION
## Summary
- use `mouseenter`/`mouseleave` instead of `mouseover`/`mouseout` for TEI DOM highlighting

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad30539c832182a911362234ef0c