### PR TITLE
Restrict hover to TEI leaves

### DIFF
--- a/src/components/aligntab.js
+++ b/src/components/aligntab.js
@@ -48,6 +48,12 @@ class AlignTab extends React.Component {
      */
     const alignLogic = (id, rootElm, domElm, teiElm) => {
       domElm.__teiElm = teiElm;
+
+      // Apply hover events only to TEI leaves (elements without TEI children)
+      if (teiElm.children.length > 0) {
+        return;
+      }
+
       domElm.addEventListener("click", (e) => {
         this.props.onSelectionChanged(domElm, teiElm, rootElm);
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- apply hover effects only on TEI elements without TEI children

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847442819c88321a9ea5ea7890944ac