### PR TITLE
Add image setter

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -83,7 +83,8 @@ const helpers = [
   {
     setter: (dom, data) => {
       if (data.project.pubStatement) {
-        TEIPubStatement(dom).iterateNext().textContent = data.project.pubStatement;
+        TEIPubStatement(dom).iterateNext().textContent =
+          data.project.pubStatement;
       }
     },
     getter: (dom, data) => {
@@ -110,7 +111,9 @@ const helpers = [
       const titleStmt = tsRes.iterateNext();
       if (!titleStmt) return;
 
-      Array.from(titleStmt.querySelectorAll("author")).forEach((e) => e.remove());
+      Array.from(titleStmt.querySelectorAll("author")).forEach((e) =>
+        e.remove(),
+      );
 
       if (Array.isArray(data.project.authors)) {
         data.project.authors.forEach((a) => {
@@ -149,7 +152,9 @@ const helpers = [
       const titleStmt = tsRes.iterateNext();
       if (!titleStmt) return;
 
-      Array.from(titleStmt.querySelectorAll("respStmt")).forEach((e) => e.remove());
+      Array.from(titleStmt.querySelectorAll("respStmt")).forEach((e) =>
+        e.remove(),
+      );
 
       if (Array.isArray(data.project.resps)) {
         data.project.resps.forEach((r) => {
@@ -739,12 +744,23 @@ class Data {
       url,
       type,
     });
+    this.#changed = true;
   }
 
   deleteImage(language, index) {
     if (this.#documents[language] && this.#documents[language].images) {
       this.#documents[language].images.splice(index, 1);
+      this.#changed = true;
     }
+  }
+
+  setImages(language, images) {
+    if (!this.#documents[language]) {
+      this.#documents[language] = {};
+    }
+
+    this.#documents[language].images = Array.isArray(images) ? images : [];
+    this.#changed = true;
   }
 
   async readFromFile(file) {

--- a/tests/Data.test.js
+++ b/tests/Data.test.js
@@ -1,13 +1,24 @@
-import Data from '../src/Data';
+import Data from "../src/Data";
 
-test('generateTEI includes TEI root and teiHeader', () => {
+test("generateTEI includes TEI root and teiHeader", () => {
   const xml = Data.generateTEI();
-  expect(xml).toContain('<TEI');
-  expect(xml).toContain('<teiHeader>');
+  expect(xml).toContain("<TEI");
+  expect(xml).toContain("<teiHeader>");
 });
 
-test('alignment category added as join type', () => {
-  Data.addAlignment('en', 'de', ['a1', 'a2'], ['b1', 'b2'], 'Semantic');
+test("alignment category added as join type", () => {
+  Data.addAlignment("en", "de", ["a1", "a2"], ["b1", "b2"], "Semantic");
   const xml = Data.generateTEI();
   expect(xml).toMatch(/<join[^>]*type="Semantic"/);
+});
+
+test("setImages saves images and getImages retrieves them", () => {
+  const img = {
+    id: "img1",
+    ids: ["a1"],
+    url: "http://example.com/img.jpg",
+    type: "URL",
+  };
+  Data.setImages("en", [img]);
+  expect(Data.getImages("en")).toEqual([img]);
 });


### PR DESCRIPTION
## Summary
- save changed state when adding/deleting images
- add `setImages` helper on `Data`
- add tests for saving images

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489a90dff08321a4b1d3339f2e9916