### PR TITLE
Add proxy server configuration in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom --watchAll=false",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "proxy": "node proxy-server.js"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -18,7 +19,12 @@
     "openseadragon": "^4.1.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "^5.0.0"
+    "react-scripts": "^5.0.0",
+    "@koa/cors": "^5.0.0",
+    "@koa/router": "^12.0.0",
+    "koa": "^2.15.0",
+    "koa-bodyparser": "^4.4.0",
+    "node-fetch": "^3.3.2"
   },
   "browserslist": {
     "production": [

--- a/proxy-server.js
+++ b/proxy-server.js
@@ -1,0 +1,53 @@
+const Koa = require('koa');
+const Router = require('@koa/router');
+const bodyParser = require('koa-bodyparser');
+const cors = require('@koa/cors');
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+const TARGET = process.env.EXIST_PROXY_TARGET || 'http://localhost:8080';
+const PORT = process.env.PORT || 3001;
+
+const app = new Koa();
+app.use(cors());
+app.use(bodyParser());
+
+const router = new Router();
+
+function isValidExistURL(url) {
+  try {
+    const u = new URL(url);
+    return u.pathname.includes('exist') || u.hostname.includes('exist');
+  } catch (e) {
+    return false;
+  }
+}
+
+router.post('/proxy', async (ctx) => {
+  const { url, path, method = 'GET', params, headers, body } = ctx.request.body;
+  const base = url && isValidExistURL(url) ? url : TARGET;
+  if (!isValidExistURL(base)) {
+    ctx.status = 400;
+    ctx.body = 'Invalid target';
+    return;
+  }
+  let dest = base;
+  if (path) dest += path.startsWith('/') ? path : '/' + path;
+  if (params) {
+    const paramString = new URLSearchParams(params).toString();
+    if (paramString) dest += '?' + paramString;
+  }
+  const options = { method, headers, body: undefined };
+  if (body && method !== 'GET' && method !== 'HEAD') {
+    options.body = body;
+  }
+  const resp = await fetch(dest, options);
+  const text = await resp.text();
+  ctx.status = resp.status;
+  resp.headers.forEach((value, key) => ctx.set(key, value));
+  ctx.body = text;
+});
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+app.listen(PORT, () => console.log(`Proxy server listening on ${PORT}`));

--- a/src/Data.js
+++ b/src/Data.js
@@ -798,8 +798,8 @@ class Data {
     this.#changed = false;
   }
 
-  async readFromExistDB(url, collection, user, password) {
-    const files = await listCollection(url, collection, user, password);
+  async readFromExistDB(url, collection, user, password, proxy) {
+    const files = await listCollection(url, collection, user, password, proxy);
     const parser = new DOMParser();
     const dom = parser.parseFromString(
       `<TEI xmlns="${TEI_NS}"><teiHeader/><standOff/></TEI>`,
@@ -807,19 +807,21 @@ class Data {
     );
 
     for (const name of files) {
-      const xml = await fetchFile(url, collection, name, user, password);
+      const xml = await fetchFile(url, collection, name, user, password, proxy);
       const fileDom = parser.parseFromString(xml, "text/xml");
       if (!fileDom.firstElementChild) continue;
-      dom.documentElement.appendChild(dom.importNode(fileDom.documentElement, true));
+      dom.documentElement.appendChild(
+        dom.importNode(fileDom.documentElement, true),
+      );
     }
 
     const s = new XMLSerializer();
     this.readFromString(s.serializeToString(dom));
   }
 
-  async saveToExistDB(url, collection, user, password) {
+  async saveToExistDB(url, collection, user, password, proxy) {
     const xml = this.generateTEI();
-    await writeFile(url, collection, "discept.xml", xml, user, password);
+    await writeFile(url, collection, "discept.xml", xml, user, password, proxy);
     this.#changed = false;
   }
 

--- a/src/components/existdbsync.js
+++ b/src/components/existdbsync.js
@@ -24,11 +24,15 @@ export default function ExistDBSync() {
     localStorage.getItem("exist-user") || "",
   );
   const [password, setPassword] = React.useState("");
+  const [proxy, setProxy] = React.useState(
+    localStorage.getItem("exist-proxy") || "",
+  );
 
   const savePrefs = () => {
     localStorage.setItem("exist-url", url);
     localStorage.setItem("exist-collection", collection);
     localStorage.setItem("exist-user", user);
+    localStorage.setItem("exist-proxy", proxy);
   };
 
   const showError = (err) => {
@@ -44,7 +48,7 @@ export default function ExistDBSync() {
   const load = async () => {
     savePrefs();
     try {
-      await data.readFromExistDB(url, collection, user, password);
+      await data.readFromExistDB(url, collection, user, password, proxy);
       setOpen(false);
     } catch (e) {
       showError(e);
@@ -54,7 +58,7 @@ export default function ExistDBSync() {
   const save = async () => {
     savePrefs();
     try {
-      await data.saveToExistDB(url, collection, user, password);
+      await data.saveToExistDB(url, collection, user, password, proxy);
       setOpen(false);
     } catch (e) {
       showError(e);
@@ -96,6 +100,12 @@ export default function ExistDBSync() {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="Proxy URL (optional)"
+            value={proxy}
+            onChange={(e) => setProxy(e.target.value)}
             fullWidth
           />
         </DialogContent>

--- a/src/existdb.js
+++ b/src/existdb.js
@@ -4,49 +4,100 @@ export function authHeader(user, password) {
   return { Authorization: `Basic ${encoded}` };
 }
 
-export async function listCollection(url, collection, user, password) {
+async function proxyFetch(body, proxy) {
+  const res = await fetch(`${proxy}/proxy`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error("exist-network");
+  return res;
+}
+
+export async function listCollection(url, collection, user, password, proxy) {
   try {
-    const res = await fetch(`${url}/rest${collection}/`, {
+    const fetchArgs = {
       headers: authHeader(user, password),
-    });
-    if (!res.ok) throw new Error('exist-list');
+    };
+    const res = proxy
+      ? await proxyFetch(
+          {
+            url,
+            path: `/rest${collection}/`,
+            method: "GET",
+            headers: fetchArgs.headers,
+          },
+          proxy,
+        )
+      : await fetch(`${url}/rest${collection}/`, fetchArgs);
+    if (!res.ok) throw new Error("exist-list");
     const text = await res.text();
-    const dom = new DOMParser().parseFromString(text, 'text/xml');
-    return Array.from(dom.getElementsByTagName('exist:resource'))
-      .map((e) => e.getAttribute('name'))
-      .filter((n) => n && n.endsWith('.xml'));
+    const dom = new DOMParser().parseFromString(text, "text/xml");
+    return Array.from(dom.getElementsByTagName("exist:resource"))
+      .map((e) => e.getAttribute("name"))
+      .filter((n) => n && n.endsWith(".xml"));
   } catch (e) {
-    if (e.name === 'TypeError') throw new Error('exist-network');
+    if (e.name === "TypeError") throw new Error("exist-network");
     throw e;
   }
 }
 
-export async function fetchFile(url, collection, name, user, password) {
+export async function fetchFile(url, collection, name, user, password, proxy) {
   try {
-    const res = await fetch(`${url}/rest${collection}/${name}`, {
-      headers: authHeader(user, password),
-    });
-    if (!res.ok) throw new Error('exist-fetch');
+    const fetchArgs = { headers: authHeader(user, password) };
+    const res = proxy
+      ? await proxyFetch(
+          {
+            url,
+            path: `/rest${collection}/${name}`,
+            method: "GET",
+            headers: fetchArgs.headers,
+          },
+          proxy,
+        )
+      : await fetch(`${url}/rest${collection}/${name}`, fetchArgs);
+    if (!res.ok) throw new Error("exist-fetch");
     return await res.text();
   } catch (e) {
-    if (e.name === 'TypeError') throw new Error('exist-network');
+    if (e.name === "TypeError") throw new Error("exist-network");
     throw e;
   }
 }
 
-export async function writeFile(url, collection, name, xml, user, password) {
+export async function writeFile(
+  url,
+  collection,
+  name,
+  xml,
+  user,
+  password,
+  proxy,
+) {
   try {
-    const res = await fetch(`${url}/rest${collection}/${name}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/xml',
-        ...authHeader(user, password),
-      },
-      body: xml,
-    });
-    if (!res.ok) throw new Error('exist-save');
+    const headers = {
+      "Content-Type": "application/xml",
+      ...authHeader(user, password),
+    };
+    const body = xml;
+    const res = proxy
+      ? await proxyFetch(
+          {
+            url,
+            path: `/rest${collection}/${name}`,
+            method: "PUT",
+            headers,
+            body,
+          },
+          proxy,
+        )
+      : await fetch(`${url}/rest${collection}/${name}`, {
+          method: "PUT",
+          headers,
+          body,
+        });
+    if (!res.ok) throw new Error("exist-save");
   } catch (e) {
-    if (e.name === 'TypeError') throw new Error('exist-network');
+    if (e.name === "TypeError") throw new Error("exist-network");
     throw e;
   }
 }


### PR DESCRIPTION
## Summary
- make proxy URL configurable through eXistDB sync dialog
- pass proxy parameter through Data helpers
- allow existdb.js functions to accept proxy URL directly, skipping env fallback
- provide Koa-based proxy server

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: could not reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68727cc6c23c83218bd97a5b2058a5d0