### PR TITLE
Add error handling in proxy

### DIFF
--- a/proxy-server.js
+++ b/proxy-server.js
@@ -40,11 +40,16 @@ router.post('/proxy', async (ctx) => {
   if (body && method !== 'GET' && method !== 'HEAD') {
     options.body = body;
   }
-  const resp = await fetch(dest, options);
-  const text = await resp.text();
-  ctx.status = resp.status;
-  resp.headers.forEach((value, key) => ctx.set(key, value));
-  ctx.body = text;
+  try {
+    const resp = await fetch(dest, options);
+    const text = await resp.text();
+    ctx.status = resp.status;
+    resp.headers.forEach((value, key) => ctx.set(key, value));
+    ctx.body = text;
+  } catch (e) {
+    ctx.status = 502;
+    ctx.body = `Errore di connessione al server finale: ${e.message}`;
+  }
 });
 
 app.use(router.routes());


### PR DESCRIPTION
## Summary
- handle network errors in proxy-server.js so upstream issues return a meaningful error and status code

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687286af81708321aaa25103f2b614d2