### PR TITLE
Fix incorrect gzip headers in proxy

### DIFF
--- a/proxy-server.js
+++ b/proxy-server.js
@@ -44,7 +44,11 @@ router.post('/proxy', async (ctx) => {
     const resp = await fetch(dest, options);
     const text = await resp.text();
     ctx.status = resp.status;
-    resp.headers.forEach((value, key) => ctx.set(key, value));
+    resp.headers.forEach((value, key) => {
+      if (key.toLowerCase() !== 'content-encoding' && key.toLowerCase() !== 'content-length') {
+        ctx.set(key, value);
+      }
+    });
     ctx.body = text;
   } catch (e) {
     ctx.status = 502;


### PR DESCRIPTION
## Summary
- proxy server: strip `Content-Encoding` and `Content-Length` headers from upstream

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687289bf0eec8321956e367549d4e95f